### PR TITLE
docs: embedded AI agent chat (user guide + plugin/admin page)

### DIFF
--- a/website/docs/features/ai-agent-chat.md
+++ b/website/docs/features/ai-agent-chat.md
@@ -1,0 +1,82 @@
+---
+sidebar_position: 94
+---
+
+# AI Agent Chat
+
+An embedded AI assistant that answers questions about your workspace data and helps you operate the platform — browsing pages, filling forms, and submitting them with your explicit approval.
+
+## Overview
+
+The AI Agent Chat lives in a collapsible sidebar between the navigation menu and the page content, giving the platform a three-column layout:
+
+```
+┌────────┬──────────────┬──────────────────────┐
+│  Menu  │   AI Chat    │        Canvas        │
+│        │  (sidebar)   │   (platform pages)   │
+└────────┴──────────────┴──────────────────────┘
+```
+
+| Aspect           | Details                                                          |
+| ---------------- | ---------------------------------------------------------------- |
+| **Availability** | Users with the `AI_CHAT_ACCESS` permission, when an AI provider is configured |
+| **Toggle**       | Chat icon in the header                                          |
+| **Collapse**     | Press `Escape` to collapse the sidebar                           |
+| **State**        | Open/collapsed state is remembered across sessions               |
+
+:::note
+If the chat icon does not appear in the header, either your role lacks the `AI_CHAT_ACCESS` permission or no AI provider has been configured for your tenant/server. See [AI Chat Plugin](../plugins-built-in/ai-chat-plugin) for configuration.
+:::
+
+## What It Can Do
+
+### Answer questions about your data
+
+Ask about tasks, projects, employees, time tracking, invoices, contacts, time off, and more:
+
+- "Which tasks assigned to me are overdue?"
+- "How many hours did the design team track last week?"
+- "Show me unpaid invoices for Acme Corp."
+
+The agent queries the Gauzy API **as you** — it can only ever see data that your own user role and organization membership allow. Answers are always limited to what you could see yourself in the UI.
+
+### Open platform pages next to the chat
+
+The agent can navigate the canvas (the main content area) to any platform page while the conversation stays open — for example, "open the time tracking report" or "take me to the new invoice form".
+
+### Read and fill forms — you approve
+
+On the currently open page, the agent can:
+
+1. **Read** the form and its current values
+2. **Fill** fields based on your instructions
+3. **Submit** the form — but **only after you click Approve** in the chat
+
+:::caution
+Any action that modifies data — submitting a form, creating, updating, or deleting a record — always pauses and asks for your approval in the chat before it executes. Nothing is written on your behalf without an explicit click on **Approve**.
+:::
+
+## Playground
+
+A dedicated playground page is available at `/pages/playground` for experimenting with the configured AI providers and models before (or alongside) using the embedded chat.
+
+## Permissions
+
+| Permission         | Grants                                                             |
+| ------------------ | ------------------------------------------------------------------ |
+| `AI_CHAT_ACCESS`   | Use the AI Agent Chat sidebar and playground                       |
+| `AI_CHAT_SETTINGS` | Configure per-tenant AI provider API keys (Settings → AI Providers) |
+
+Permissions are assigned per role — see [Custom Roles & Permissions](./custom-roles-permissions).
+
+## Security Model
+
+- The agent calls the Gauzy REST API with **your own JWT** — role-based access control and tenant isolation always apply.
+- Read-only questions run directly; **mutating tools require in-chat approval**.
+- Provider API keys are stored encrypted on the server and are never exposed to the browser.
+
+## Related Pages
+
+- [AI Chat Plugin](../plugins-built-in/ai-chat-plugin) — providers, configuration, self-hosting, and architecture
+- [Custom Roles & Permissions](./custom-roles-permissions)
+- [Permissions Reference](../reference/permissions-reference)

--- a/website/docs/features/ai-agent-chat.md
+++ b/website/docs/features/ai-agent-chat.md
@@ -10,7 +10,7 @@ An embedded AI assistant that answers questions about your workspace data and he
 
 The AI Agent Chat lives in a collapsible sidebar between the navigation menu and the page content, giving the platform a three-column layout:
 
-```
+```text
 ┌────────┬──────────────┬──────────────────────┐
 │  Menu  │   AI Chat    │        Canvas        │
 │        │  (sidebar)   │   (platform pages)   │
@@ -20,9 +20,12 @@ The AI Agent Chat lives in a collapsible sidebar between the navigation menu and
 | Aspect           | Details                                                          |
 | ---------------- | ---------------------------------------------------------------- |
 | **Availability** | Users with the `AI_CHAT_ACCESS` permission, when an AI provider is configured |
-| **Toggle**       | Chat icon in the header                                          |
+| **Toggle**       | Robot icon in the navigation sidebar (next to the logo)          |
+| **Position**     | Dockable to either side of the canvas                            |
+| **Size**         | Drag the divider to resize; maximize to full width; detach into a separate browser window |
 | **Collapse**     | Press `Escape` to collapse the sidebar                           |
-| **State**        | Open/collapsed state is remembered across sessions               |
+| **State**        | Open/collapsed state, position, and width are remembered across sessions |
+| **History**      | Conversations are saved per user and can be reopened or deleted  |
 
 :::note
 If the chat icon does not appear in the header, either your role lacks the `AI_CHAT_ACCESS` permission or no AI provider has been configured for your tenant/server. See [AI Chat Plugin](../plugins-built-in/ai-chat-plugin) for configuration.
@@ -55,6 +58,10 @@ On the currently open page, the agent can:
 :::caution
 Any action that modifies data — submitting a form, creating, updating, or deleting a record — always pauses and asks for your approval in the chat before it executes. Nothing is written on your behalf without an explicit click on **Approve**.
 :::
+
+### Voice dictation
+
+The microphone icon in the chat input records speech and transcribes it into the message box — a recording panel above the input shows the elapsed time and offers **Cancel**, **Done**, and an optional auto-send toggle. Dictation requires a configured provider with speech support (currently OpenAI).
 
 ## Playground
 

--- a/website/docs/plugins-built-in/ai-chat-plugin.md
+++ b/website/docs/plugins-built-in/ai-chat-plugin.md
@@ -1,0 +1,121 @@
+---
+sidebar_position: 7
+---
+
+# AI Chat Plugin
+
+Backend and frontend plugins powering the embedded [AI Agent Chat](../features/ai-agent-chat) — a provider-pluggable AI assistant that answers questions about tenant data and operates the platform UI with user approval.
+
+## Overview
+
+| Property             | Value                                     |
+| -------------------- | ----------------------------------------- |
+| **Package**          | `@gauzy/plugin-ai-chat`                   |
+| **Source**           | `packages/plugins/ai-chat`                |
+| **UI Package**       | `@gauzy/plugin-ai-chat-react-ui`          |
+| **UI Source**        | `packages/plugins/ai-chat-react-ui`       |
+| **API Endpoints**    | `POST /api/ai-chat`, `GET /api/ai-chat/config`, `/api/ai-chat/credentials` |
+
+## Providers
+
+Each AI provider is its own plugin implementing `IAiChatProviderDefinition`, registered in the `AiProviderRegistry`:
+
+| Provider              | Status                | Default Model     |
+| --------------------- | --------------------- | ----------------- |
+| **Anthropic**         | Default               | `claude-sonnet-5` |
+| **OpenAI**            | Supported             | —                 |
+| **OpenRouter**        | Supported             | —                 |
+| **Vercel AI Gateway** | Supported             | —                 |
+| **Gauzy AI**          | Placeholder           | —                 |
+
+:::note
+The Gauzy AI provider is currently a placeholder — chat traffic is not yet routed through the [Gauzy AI server](./ai-plugin). Use one of the other providers.
+:::
+
+## Configuration
+
+There are two ways to configure provider credentials. **Per-tenant keys take precedence** over server environment variables.
+
+### Option 1: Per-tenant BYOK (recommended for multi-tenant)
+
+Users with the `AI_CHAT_SETTINGS` permission can add provider API keys under **Settings → AI Providers**. Keys are stored encrypted at rest using the server's `ENCRYPTION_KEY`.
+
+### Option 2: Server environment variables
+
+```bash
+# Enable the AI chat feature
+GAUZY_AI_CHAT_ENABLED=true
+
+# Default provider and model
+GAUZY_AI_CHAT_DEFAULT_PROVIDER=anthropic
+GAUZY_AI_CHAT_DEFAULT_MODEL=claude-sonnet-5
+
+# Provider API keys (set the ones you use)
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+OPENROUTER_API_KEY=sk-or-...
+AI_GATEWAY_API_KEY=...
+
+# Optional: custom base URLs per provider
+# ANTHROPIC_BASE_URL=...
+# OPENAI_BASE_URL=...
+# OPENROUTER_BASE_URL=...
+```
+
+### Advanced options
+
+| Variable                     | Description                                                                 |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| `GAUZY_AI_CHAT_MCP_URL`      | Connect the agent to an external MCP server for extra tools. **Off by default.** |
+| `GAUZY_AI_CHAT_SELF_API_URL` | Override the base URL the agent uses to call the Gauzy API itself           |
+
+:::caution
+`GAUZY_AI_CHAT_MCP_URL` is an advanced option. Any MCP server you connect gains tool-level access within the agent loop — only point it at servers you control and trust.
+:::
+
+## Security Model
+
+- **User-scoped API access** — the agent calls the Gauzy REST API with the requesting user's own JWT. Role-based access control and tenant isolation always apply; the agent can never read or write more than the user could via the UI.
+- **Human-in-the-loop mutations** — tools that modify data (form submission, create/update/delete) require explicit user approval in the chat before executing.
+- **Encrypted credentials** — per-tenant BYOK keys are encrypted with `ENCRYPTION_KEY` and never sent to the browser.
+
+## Architecture
+
+```mermaid
+graph LR
+    subgraph Browser
+        UI["@gauzy/plugin-ai-chat-react-ui<br/>(Vercel AI SDK 7, streaming UI messages)"]
+    end
+    subgraph API["Gauzy API"]
+        CHAT["@gauzy/plugin-ai-chat<br/>POST /api/ai-chat"]
+        REG["AiProviderRegistry"]
+        REST["Gauzy REST API<br/>(user's JWT, RBAC)"]
+    end
+    subgraph Providers
+        ANT["Anthropic"]
+        OAI["OpenAI"]
+        ORT["OpenRouter"]
+        VAG["Vercel AI Gateway"]
+    end
+
+    UI -- "streaming UI message protocol" --> CHAT
+    CHAT --> REG
+    REG --> ANT & OAI & ORT & VAG
+    CHAT -- "tool calls" --> REST
+```
+
+- **Frontend** — `@gauzy/plugin-ai-chat-react-ui` renders the chat sidebar using the Vercel AI SDK 7 and its streaming UI message protocol.
+- **Backend** — `@gauzy/plugin-ai-chat` exposes `POST /api/ai-chat` (chat completion stream), `GET /api/ai-chat/config` (feature/provider availability), and `/api/ai-chat/credentials` (per-tenant BYOK management).
+- **Providers** — one plugin per provider, each implementing `IAiChatProviderDefinition` and registering itself in the `AiProviderRegistry`.
+
+For implementation details, see the package READMEs on GitHub:
+
+- [`packages/plugins/ai-chat`](https://github.com/ever-co/ever-gauzy/tree/develop/packages/plugins/ai-chat)
+- [`packages/plugins/ai-chat-react-ui`](https://github.com/ever-co/ever-gauzy/tree/develop/packages/plugins/ai-chat-react-ui)
+
+## Related Pages
+
+- [AI Agent Chat (user guide)](../features/ai-agent-chat)
+- [AI Plugin (Gauzy AI server)](./ai-plugin)
+- [Environment Variables](../reference/environment-variables)
+- [Permissions Reference](../reference/permissions-reference)

--- a/website/docs/plugins-built-in/ai-chat-plugin.md
+++ b/website/docs/plugins-built-in/ai-chat-plugin.md
@@ -14,19 +14,33 @@ Backend and frontend plugins powering the embedded [AI Agent Chat](../features/a
 | **Source**           | `packages/plugins/ai-chat`                |
 | **UI Package**       | `@gauzy/plugin-ai-chat-react-ui`          |
 | **UI Source**        | `packages/plugins/ai-chat-react-ui`       |
-| **API Endpoints**    | `POST /api/ai-chat`, `GET /api/ai-chat/config`, `/api/ai-chat/credentials` |
+| **API Endpoints**    | See [API Endpoints](#api-endpoints) below |
+
+## API Endpoints
+
+| Endpoint                                   | Purpose                                                      |
+| ------------------------------------------ | ------------------------------------------------------------ |
+| `POST /api/ai-chat`                        | One chat turn as a streaming UI message response             |
+| `GET /api/ai-chat/config`                  | Feature/provider availability for the current tenant (no secrets) |
+| `POST /api/ai-chat/transcribe`             | Speech-to-text for the chat's voice dictation (25 MB limit)  |
+| `GET /api/ai-chat/providers/:id/models`    | A provider's model catalogue, for the settings model picker  |
+| `GET`/`POST`/`PUT`/`DELETE` `/api/ai-chat/credentials` | Per-tenant BYOK credential management (keys masked on read) |
+| `POST /api/ai-chat/credentials/connect`    | Completes a provider "Connect" flow (OpenRouter PKCE) server-side |
+| `GET`/`DELETE` `/api/ai-chat/conversations` | Per-user chat history                                        |
 
 ## Providers
 
 Each AI provider is its own plugin implementing `IAiChatProviderDefinition`, registered in the `AiProviderRegistry`:
 
-| Provider              | Status                | Default Model     |
-| --------------------- | --------------------- | ----------------- |
-| **Anthropic**         | Default               | `claude-sonnet-5` |
-| **OpenAI**            | Supported             | —                 |
-| **OpenRouter**        | Supported             | —                 |
-| **Vercel AI Gateway** | Supported             | —                 |
-| **Gauzy AI**          | Placeholder           | —                 |
+| Provider              | Status                | Default Model               |
+| --------------------- | --------------------- | --------------------------- |
+| **Anthropic**         | Default               | `claude-sonnet-5`           |
+| **OpenAI**            | Supported (also powers voice dictation) | `gpt-5.5` |
+| **OpenRouter**        | Supported (Connect flow + optional shared free tier) | `anthropic/claude-sonnet-5` |
+| **Google Gemini**     | Supported             | `gemini-3.5-flash`          |
+| **xAI Grok**          | Supported             | `grok-4.3`                  |
+| **Vercel AI Gateway** | Supported             | `anthropic/claude-sonnet-5` |
+| **Gauzy AI**          | Placeholder           | —                           |
 
 :::note
 The Gauzy AI provider is currently a placeholder — chat traffic is not yet routed through the [Gauzy AI server](./ai-plugin). Use one of the other providers.
@@ -54,6 +68,8 @@ GAUZY_AI_CHAT_DEFAULT_MODEL=claude-sonnet-5
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 OPENROUTER_API_KEY=sk-or-...
+GEMINI_API_KEY=...            # or GOOGLE_GENERATIVE_AI_API_KEY
+XAI_API_KEY=...               # or GROK_API_KEY
 AI_GATEWAY_API_KEY=...
 
 # Optional: custom base URLs per provider
@@ -61,6 +77,16 @@ AI_GATEWAY_API_KEY=...
 # OPENAI_BASE_URL=...
 # OPENROUTER_BASE_URL=...
 ```
+
+### Option 3: Shared free tier (operator-provided)
+
+```bash
+# A platform-supplied OpenRouter key shared by all tenants that have no key of
+# their own. Restricted to the provider's FREE models — enforced server-side.
+OPENROUTER_PLATFORM_API_KEY=sk-or-...
+```
+
+The platform key is resolved **last** — after the tenant's own key and after the operator's `OPENROUTER_API_KEY` — so it never downgrades anyone who brought a paid key. When a shared free-tier request is rate-limited, the chat tells the user and suggests adding their own key.
 
 ### Advanced options
 
@@ -95,17 +121,19 @@ graph LR
         ANT["Anthropic"]
         OAI["OpenAI"]
         ORT["OpenRouter"]
+        GEM["Gemini"]
+        GRK["Grok"]
         VAG["Vercel AI Gateway"]
     end
 
     UI -- "streaming UI message protocol" --> CHAT
     CHAT --> REG
-    REG --> ANT & OAI & ORT & VAG
+    REG --> ANT & OAI & ORT & GEM & GRK & VAG
     CHAT -- "tool calls" --> REST
 ```
 
 - **Frontend** — `@gauzy/plugin-ai-chat-react-ui` renders the chat sidebar using the Vercel AI SDK 7 and its streaming UI message protocol.
-- **Backend** — `@gauzy/plugin-ai-chat` exposes `POST /api/ai-chat` (chat completion stream), `GET /api/ai-chat/config` (feature/provider availability), and `/api/ai-chat/credentials` (per-tenant BYOK management).
+- **Backend** — `@gauzy/plugin-ai-chat` exposes the routes listed under [API Endpoints](#api-endpoints): the chat stream, runtime config, voice transcription, per-provider model catalogues, BYOK credential management (including the Connect exchange), and per-user conversation history.
 - **Providers** — one plugin per provider, each implementing `IAiChatProviderDefinition` and registering itself in the `AiProviderRegistry`.
 
 For implementation details, see the package READMEs on GitHub:

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -99,6 +99,25 @@ Comprehensive reference of all environment variables used by Ever Gauzy.
 | `THROTTLE_TTL`   | 60      | Window in seconds       |
 | `THROTTLE_LIMIT` | 100     | Max requests per window |
 
+## AI Chat
+
+See the [AI Chat Plugin](../plugins-built-in/ai-chat-plugin) page for the full setup guide.
+
+| Variable                         | Description                                                       |
+| -------------------------------- | ----------------------------------------------------------------- |
+| `GAUZY_AI_CHAT_ENABLED`          | Enable/disable the AI chat feature (`false` hides it everywhere)  |
+| `GAUZY_AI_CHAT_DEFAULT_PROVIDER` | Default provider id (e.g. `anthropic`)                            |
+| `GAUZY_AI_CHAT_DEFAULT_MODEL`    | Default model id for the default provider                         |
+| `ANTHROPIC_API_KEY`              | Anthropic server-wide key                                         |
+| `OPENAI_API_KEY`                 | OpenAI server-wide key (also powers voice dictation)              |
+| `OPENROUTER_API_KEY`             | OpenRouter server-wide key                                        |
+| `OPENROUTER_PLATFORM_API_KEY`    | Shared free-tier key, restricted to free models (resolved last)   |
+| `GEMINI_API_KEY`                 | Google Gemini key (or `GOOGLE_GENERATIVE_AI_API_KEY`)             |
+| `XAI_API_KEY`                    | xAI Grok key (or `GROK_API_KEY`)                                  |
+| `AI_GATEWAY_API_KEY`             | Vercel AI Gateway key                                             |
+| `GAUZY_AI_CHAT_MCP_URL`          | Optional external MCP server for extra agent tools (off by default) |
+| `GAUZY_AI_CHAT_SELF_API_URL`     | Override the base URL the agent uses to call the Gauzy API        |
+
 ## Related Pages
 
 - [Configuration System](../architecture/configuration-system) — config architecture

--- a/website/docs/reference/permissions-reference.md
+++ b/website/docs/reference/permissions-reference.md
@@ -121,6 +121,13 @@ Complete list of all permissions in Ever Gauzy.
 | `ORG_GOAL_VIEW` | View goals  |
 | `ORG_GOAL_EDIT` | Edit goals  |
 
+## AI
+
+| Permission         | Description                                                        |
+| ------------------ | ------------------------------------------------------------------ |
+| `AI_CHAT_ACCESS`   | Use the AI Agent Chat sidebar and playground                       |
+| `AI_CHAT_SETTINGS` | Configure per-tenant AI provider API keys (Settings → AI Providers) |
+
 ## Related Pages
 
 - [Roles & Permissions](../authentication/roles-and-permissions) — RBAC overview


### PR DESCRIPTION
Documents the embedded AI Agent Chat merged in [ever-gauzy#9769](https://github.com/ever-co/ever-gauzy/pull/9769):

- `features/ai-agent-chat.md` — user guide (Menu | Chat | Canvas layout, permissions, page navigation, form fill/approve flow, playground)
- `plugins-built-in/ai-chat-plugin.md` — admin/self-hosting + developer page (providers, BYOK vs env config, env var reference, security model, architecture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)