### PR TITLE
ci: migrate runners to self-hosted ARC fleet (stage)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Migrate the CodeQL analyze job from `ubuntu-latest` to `${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}` (smallest _4 pool per runner policy for CodeQL/SARIF jobs).

k8s-build.yml already runs on the ARC var — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)