### PR TITLE
chore: promote docs stage to master (Documents feature docs live)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/k8s-build.yml
+++ b/.github/workflows/k8s-build.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   build:
-    runs-on: ${{ vars.RUNNER_LINUX_X64_8 || vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RUNNER_LINUX_X64_4 || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -21,9 +21,9 @@ jobs:
             context: website
             build_args: ""
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v7
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -36,7 +36,7 @@ jobs:
             main|master) echo "tag=prod" >> "$GITHUB_OUTPUT" ;;
             *) echo "tag=${GITHUB_REF_NAME//\//-}" >> "$GITHUB_OUTPUT" ;;
           esac
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/website/docs/features/documents/_category_.json
+++ b/website/docs/features/documents/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "📄 Documents",
+  "position": 49,
+  "link": {
+    "type": "generated-index",
+    "description": "The Documents hub — upload files, write wiki pages, organize everything in one tree, review what needs a human, and ground AI answers in your own documents."
+  }
+}

--- a/website/docs/features/documents/ai-knowledge.md
+++ b/website/docs/features/documents/ai-knowledge.md
@@ -1,0 +1,103 @@
+---
+sidebar_position: 5
+---
+
+# AI Knowledge
+
+Let the AI assistant answer questions from your own documents — deliberately, one document at a time.
+
+## Overview
+
+Every document in the hub is searchable. Only the documents you **import into AI knowledge** can be used by the AI assistant to answer questions.
+
+That distinction is the whole point of the feature. Uploading a file puts it in the hub; importing it into knowledge is a separate, explicit, reversible decision. Nothing is ever added to AI knowledge automatically without someone choosing it.
+
+:::warning
+**AI features are turned off by default.** Classification, summaries, and AI answers only work once an administrator enables them for the deployment **and** an AI provider is configured. Until then, uploads still have their text read out and stay fully searchable — you simply get keyword search instead of AI answers. See [Settings](./settings).
+:::
+
+## Uploaded vs Imported
+
+| | **Uploaded only** | **Imported into AI knowledge** |
+| --- | --- | --- |
+| Stored in the hub | ✅ | ✅ |
+| Found by name search | ✅ | ✅ |
+| Found by content search | ✅ | ✅ |
+| Used by the AI assistant to answer questions | ❌ | ✅ |
+
+The **Knowledge** badge on each document tells you where it stands:
+
+| Badge                 | Meaning                                                   |
+| --------------------- | --------------------------------------------------------- |
+| **Not in knowledge**  | Present in the hub, never imported                        |
+| **Queued**            | Waiting to be processed for AI knowledge                  |
+| **Indexing**          | Being prepared right now                                  |
+| **In AI knowledge**   | Available to the assistant                                |
+| **Indexing failed**   | Something went wrong — try importing again                |
+| **Excluded**          | Deliberately opted out                                    |
+
+## Importing a Document
+
+1. Open the document and expand the detail panel
+2. Switch on **In AI knowledge** (or use **Import to AI knowledge**)
+
+The document is prepared in the background — its text is split into passages so that the assistant can quote the right part of a long file rather than the whole thing. The badge moves to **In AI knowledge** when it is ready.
+
+You can also select many documents at once and use **Import to knowledge** from the bulk bar.
+
+:::tip
+Administrators can make **Add to AI knowledge** the default for new uploads in **Settings → Documents**, so a team that wants everything answerable does not have to remember to flip the switch each time.
+:::
+
+## Excluding a Document
+
+Turn the switch off, or use **Exclude from AI knowledge**. The document's prepared passages are deleted and it stops contributing to answers immediately. The document itself, its file, its history, and its links are untouched — only its participation in AI answers ends.
+
+Use this for anything confidential enough that it should not surface in an answer to a colleague's question, even if that colleague could open the document directly.
+
+## Re-Indexing
+
+If a document's content changes — you corrected its extracted text, or edited a page substantially — use **Re-index** in the detail panel to prepare it again. Documents whose content has not actually changed are skipped, so re-indexing is cheap and safe to repeat.
+
+## Automatic Categorization and Summaries
+
+When AI is enabled, each uploaded file is also read once for classification. That produces:
+
+- **Categories** — one to three suggestions from the organization's category catalog, added to whatever you set yourself. Categories you chose are never removed.
+- **An AI summary** — a sentence or two describing what the document is, shown in the detail panel. **Regenerate summary** re-runs it.
+- **Suggested tags** — proposals only. The assistant never creates tags on its own.
+- **A confidence score** — how sure the classifier was.
+
+If confidence is low, the document is sent to the [review queue](./reviews-and-approvals) instead of being trusted silently.
+
+## How the Assistant Uses Documents
+
+When you ask the AI assistant a question, it can search your organization's imported documents and read the relevant passages before answering. Two things are worth knowing:
+
+- **Your permissions apply.** The assistant searches as *you*. It can never surface a document you would not be allowed to open — private documents you have no access to simply are not there.
+- **Answers point back at the source.** Retrieved passages carry their location — heading, page number, or spreadsheet sheet — so an answer can be traced to the document it came from and checked.
+
+Search combines meaning-based and keyword matching where the deployment supports it. Where it does not, it falls back to keyword search automatically; administrators can see which mode is active in **Settings → Documents**.
+
+## What Keeps a Document Out of Answers
+
+A document is excluded from AI answers if **any** of these is true:
+
+- It is not imported into AI knowledge, or its import has not finished
+- It is **Excluded**
+- Its **Searchable content** switch is off
+- It is archived or deleted
+- It was **rejected** in review
+- It is AI-derived content still waiting for review — see below
+- The person asking would not be allowed to open it
+
+### The Review Safety Rule
+
+Content that the AI produced or classified with low confidence does **not** feed back into AI answers until a human approves it. That closes the loop where a machine's guess becomes a machine's source of truth. Full detail in [Reviews & Approvals](./reviews-and-approvals).
+
+## Related Pages
+
+- [Reviews & Approvals](./reviews-and-approvals) — the review queue and the safety rule
+- [Settings](./settings) — enabling AI, the category catalog, knowledge status
+- [Uploading Files](./uploading-files) — correcting the text AI answers rely on
+- [Sharing & Permissions](./sharing-and-permissions) — who may import documents

--- a/website/docs/features/documents/migrating-from-legacy.md
+++ b/website/docs/features/documents/migrating-from-legacy.md
@@ -1,0 +1,137 @@
+---
+sidebar_position: 9
+---
+
+# Migrating from the Legacy Pages
+
+What happens to Organization Documents and the Help Center when the Documents hub is switched on, and how to bring their content across.
+
+## Overview
+
+The Documents hub replaces two older areas:
+
+- **Organization Documents** — a flat list of document names and links
+- **Help Center** and the **Knowledge Base** — categorized articles
+
+Nothing about them is removed. Their data stays where it is, their APIs keep responding, and no content is deleted at any point in this process. What changes is where people are sent in the interface, and that is controlled by a switch you own.
+
+## Both Keep Working
+
+Until an administrator enables the Documents feature for an organization, absolutely nothing changes:
+
+- Organization Documents and Help Center appear in the sidebar as before
+- Their pages behave exactly as they always have
+- The Documents hub does not appear at all
+
+This is the default state. Enabling Documents is a deliberate act, and it can be reversed.
+
+## The Feature Flag
+
+The hub is governed by the **Documents** feature, toggled per organization in **Settings → Features**.
+
+| Feature state | Sidebar shows                                   | Legacy pages                                        |
+| ------------- | ----------------------------------------------- | ---------------------------------------------------- |
+| **Off**       | Organization Documents, Help Center              | Work normally                                        |
+| **On**        | Documents                                        | Redirect to the Documents hub                        |
+| **Off again** | Organization Documents, Help Center              | Work normally again — nothing was lost               |
+
+Because it is per organization, a multi-organization deployment can pilot the hub with one team before rolling it out everywhere.
+
+## Redirect Behavior
+
+Once Documents is enabled, opening a legacy Organization Documents or Help Center URL takes you to the Documents hub instead. Old links in emails, tasks, and bookmarks keep working rather than landing on a dead page — you simply arrive at the new home.
+
+The legacy route that used to open the "add document" dialog opens the Documents upload dialog instead, so that habit survives too.
+
+:::note
+Redirects change navigation only. The legacy data is untouched, and turning the feature off restores the original pages immediately.
+:::
+
+## Importing Legacy Content
+
+Redirects move people. Importing moves content. It is a separate step, and one you should always rehearse first.
+
+The import is run by an administrator holding `DOCS_MANAGE`:
+
+```bash
+# Dry run — reads, maps, validates, writes NOTHING (this is the default)
+POST /api/plugins/docs/migrations/import-legacy
+{ "dryRun": true }
+
+# Real run — requires dryRun to be set explicitly to false
+POST /api/plugins/docs/migrations/import-legacy
+{ "dryRun": false }
+
+# Optionally limit the sources
+POST /api/plugins/docs/migrations/import-legacy
+{ "dryRun": false, "sources": ["organization-document"] }
+
+# Undo a run
+POST /api/plugins/docs/migrations/import-legacy/rollback
+```
+
+:::tip
+**Dry run is the default.** Calling the import without asking for a real run gives you the complete report — everything that would be created, skipped, or flagged — with no changes made. Read that report before running it for real.
+:::
+
+Both runs return the same report: how many items were **scanned**, **created**, **skipped**, and **failed**, plus any **warnings**.
+
+### What Maps to What
+
+| Legacy item                       | Becomes                                        | Notes                                                              |
+| --------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------ |
+| The organization documents list    | A folder named **Organization Documents**       | Created once, as the home for the imported list                    |
+| An organization document          | A **file**                                      | The existing stored file is reused — nothing is copied or re-uploaded |
+| A document with no file           | A file marked **Failed**, flagged for review    | Warned about in the report                                          |
+| A document that was only a link   | A file flagged for review                       | Warned about, so somebody can attach the real file                  |
+| A help center base or category     | A **folder**                                    | Icon, color, description, and ordering are carried over            |
+| A help center article              | A **page**                                      | Content is converted for the new editor                            |
+| A draft article                    | A page marked **Needs review**                  | Drafts are not silently published                                  |
+| A private article or category      | A **Private** document                          | Warned about — see below                                            |
+| An orphaned article or category    | Parked in a **Help Center (recovered)** folder  | Nothing is dropped because its parent was missing                   |
+| Article revisions                  | Version history entries                         | Counted separately in the report                                    |
+
+Everything imports as **not in AI knowledge**. The import never puts anything into AI answers on your behalf.
+
+Duplicate names are given a numbered suffix rather than overwriting each other.
+
+:::warning
+Privacy is now enforced. In the Help Center, marking an article private mostly affected how it was displayed. In the Documents hub, **Private** genuinely restricts who can open a document. Anything that was private comes across as Private and is flagged in the report — review those items so nobody loses access to something they need.
+:::
+
+### Running It Twice Is Safe
+
+The import is idempotent. Re-running it only brings across legacy items that do not already have an imported copy. Archived and deleted copies count as existing, so a second run will not resurrect something you deliberately removed. If a run is already in progress for an organization, a second request is refused rather than allowed to overlap.
+
+### Rolling Back
+
+The rollback removes the documents a migration created. It is deliberately conservative:
+
+- Imported documents that have been **edited since the import** are left alone
+- Imported folders that now contain **non-imported** documents are left alone
+- Nothing physical is deleted — file storage is untouched, and the legacy tables are never modified
+
+A forced rollback overrides the first two rails. Even then it does not delete anything that was not created by the migration; documents that ended up inside a removed folder are moved up to the top of the tree instead.
+
+:::note
+The import and rollback are run against the API today. A screen for this in **Settings → Documents** is planned for a later release.
+:::
+
+## Suggested Rollout
+
+1. Enable **Documents** for one organization
+2. Run the import as a **dry run** and read the report
+3. Fix anything obviously wrong in the legacy data, then dry run again
+4. Run it for real
+5. Review everything flagged **Needs review**, especially items that became Private
+6. Decide, document by document, what belongs in [AI knowledge](./ai-knowledge)
+7. Repeat for the remaining organizations
+
+## Related Pages
+
+- [Documents Overview](./overview) — what replaces the legacy pages
+- [Settings](./settings) — the feature toggle and organization defaults
+- [Reviews & Approvals](./reviews-and-approvals) — clearing what the import flagged
+- [Organization Documents](../organization-documents) — the legacy list
+- [Help Center](../help-center) — the legacy customer-facing help center
+- [Knowledge Base](../knowledge-base) — the legacy internal knowledge base

--- a/website/docs/features/documents/organizing.md
+++ b/website/docs/features/documents/organizing.md
@@ -1,0 +1,143 @@
+---
+sidebar_position: 3
+---
+
+# Organizing Documents
+
+Structure the tree, classify with categories and tags, and find anything again with search and filters.
+
+## Overview
+
+The Documents page has three parts: the **tree** on the left, the **list** in the middle (as a table or as cards), and a **detail panel** for whatever you select. The tree is the structure; categories, tags, and filters are how you cut across it.
+
+## The Folder Tree
+
+The tree sidebar shows three sections:
+
+| Section           | Contents                                     |
+| ----------------- | -------------------------------------------- |
+| **All documents** | The full tree, starting at the root          |
+| **Favorites**     | Documents you have starred                   |
+| **Recents**       | Documents you opened recently                |
+
+Folders load their children as you expand them, so a large tree stays fast. You can collapse the whole sidebar to give the list more room; the choice is remembered on your device.
+
+Right-click (or use the "…" button on) any node for its menu:
+
+**New folder · New page · Upload here · Rename · Move… · Duplicate · Duplicate with children · Copy link · Archive · Restore · Delete**
+
+**Copy link** puts a direct link to that document on your clipboard — handy for chat messages and task descriptions.
+
+## Moving and Re-Parenting
+
+Two ways to move something:
+
+- **Drag it** in the tree onto its new parent
+- Open **Move…** from the node menu, search for the destination folder, and click **Move here**
+
+A document can never be moved into its own subtree — the tree refuses the drop and the dialog explains why. Moving a folder takes everything inside it along.
+
+## Categories vs Tags
+
+Both classify a document, but they are not the same thing and they are managed differently.
+
+| | **Categories** | **Tags** |
+| --- | --- | --- |
+| Purpose | Curated business taxonomy | Free-form labelling |
+| Managed by | Administrators, in **Settings → Documents** | Anyone, inline |
+| Scope | The Documents hub | The whole platform |
+| Examples | Invoice, Contract, Policy, HR, Legal | `q4`, `urgent`, `client-acme` |
+| Set automatically | Yes, when AI classification is on | No — AI suggests, but never creates tags |
+
+In short: **categories classify, tags label**. Use categories to answer "what kind of document is this?" and tags for anything else.
+
+## Favorites
+
+Click the star on a document to add it to **Favorites**. Favorites use the platform-wide favorites system, so they behave like favorites everywhere else in Gauzy.
+
+## Archiving, and Archive Before Delete
+
+Archiving takes a document out of everyday view without destroying anything. Archived documents keep their content, their links, and their history — they are simply filtered out by default and excluded from AI answers.
+
+- **Archive** a document from its node menu or detail panel
+- Archiving a **folder** archives everything inside it
+- **Restore** puts it back
+
+Deleting is deliberately a two-step action: **a document must be archived before it can be deleted.** The delete button only appears once a document is archived. This makes accidental one-click destruction of a folder tree impossible.
+
+When you delete a folder that still has contents, you choose what happens to them:
+
+| Option                                       | Result                                        |
+| -------------------------------------------- | --------------------------------------------- |
+| **Delete everything inside it**              | The folder and its whole subtree are removed   |
+| **Keep children and move them up one level** | Only the folder goes; its contents are promoted |
+
+## Search
+
+The search box sits above the list, with a toggle for what it searches:
+
+| Mode         | Searches                                                   |
+| ------------ | ---------------------------------------------------------- |
+| **Names**    | Document names only — fast, matches as you type            |
+| **Content**  | The text read out of files, plus the content of pages       |
+
+Content search needs a slightly longer query than name search — type at least three characters before it runs.
+
+### Keeping a Document Out of Content Search
+
+Each file has a **Searchable content** switch in its detail panel. Turn it off and only the name, categories, and tags will match — the content is skipped. This is the right control for a document that should stay in the hub but must not surface in content search or AI answers.
+
+## Filters
+
+The filter bar narrows the list. Everything combines.
+
+**Presets** — one-click starting points:
+
+| Preset                | Shows                                          |
+| --------------------- | ---------------------------------------------- |
+| **All**               | Everything (the default)                       |
+| **Needs review**      | Documents waiting for a human                  |
+| **Not in AI knowledge** | Documents that are not part of AI answers    |
+| **Archived**          | Archived documents                             |
+
+**Facets** — multi-select, each showing a live count of matching documents: Kind, Status, Knowledge, Source, Category, Tag.
+
+**Date ranges** — filter by **Created** or **Updated**.
+
+**Clear all** resets everything back to the default view.
+
+### Sharing a Filtered View
+
+The filters live in the page address. Once you have the view you want, copy the URL from your browser and send it to a colleague — they will open the same filtered list, subject to their own permissions. Bookmarking works the same way.
+
+### Saved Views
+
+**Saved views** store the current filter set under a name so you can jump back to it. As the dialog says, saved views are kept **on this device only** — they do not follow you to another browser and cannot be shared with colleagues. Use the URL for that.
+
+## Table and Cards
+
+Switch the list between **Table** and **Cards** with the view toggle. Table view is denser and sortable; cards view is easier to scan for files with previews. Your choice is remembered.
+
+## Bulk Actions
+
+Select several documents with their checkboxes and a bulk bar appears. Available actions:
+
+| Action                       | Notes                                             |
+| ---------------------------- | ------------------------------------------------- |
+| **Archive** / **Unarchive**  | Same rules as archiving one document               |
+| **Set categories**           | Replaces each document's full category set         |
+| **Add tags** / **Remove tags** | Adds or removes without touching other tags      |
+| **Move**                     | Requires you to pick a destination folder          |
+| **Import to knowledge** / **Exclude from knowledge** | See [AI Knowledge](./ai-knowledge) |
+| **Approve** / **Reject**     | See [Reviews & Approvals](./reviews-and-approvals) |
+| **Delete**                   | Only affects documents that are already archived   |
+
+Bulk actions run per document and report back how many succeeded and how many failed, with a copyable report of anything that did not work.
+
+## Related Pages
+
+- [Documents Overview](./overview) — the three kinds of item
+- [Uploading Files](./uploading-files) — getting files in
+- [Settings](./settings) — managing the category catalog
+- [Tags & Labels](../tags-and-labels) — the platform-wide tag system
+- [Bulk Operations](../bulk-operations) — bulk actions elsewhere in Gauzy

--- a/website/docs/features/documents/overview.md
+++ b/website/docs/features/documents/overview.md
@@ -1,0 +1,99 @@
+---
+sidebar_position: 1
+---
+
+# Documents Overview
+
+A central hub for every document in your organization — uploaded files, wiki pages written in the platform, and the folders that hold them.
+
+## Overview
+
+**Documents** appears as a top-level entry in the main sidebar, directly below **Dashboards**. Everything lives in a single tree that belongs to the organization, so a file uploaded by Finance and a policy page written by HR sit side by side and are found by the same search.
+
+The hub gives you:
+
+- One tree of folders, pages, and files — no separate silos per department
+- Search by name **or** by the text inside a file
+- Categories, tags, favorites, and filters to slice the tree any way you need
+- A review queue for anything that needs a human to look at it
+- Optional AI knowledge, so the assistant can answer questions from your own documents
+
+Documents is organization-scoped. The project, team, employee, and date selectors in the page header do not apply to it.
+
+## The Three Kinds of Item
+
+Everything in the hub is a document. What it can do depends on its kind.
+
+| Kind       | What it is                                       | Can contain children | Created by                        |
+| ---------- | ------------------------------------------------ | -------------------- | --------------------------------- |
+| **Folder** | A container used to structure the tree            | ✅                   | **New folder** in the tree menu   |
+| **Page**   | A wiki-style page written in the built-in editor  | ✅                   | **New page**                      |
+| **File**   | An uploaded binary — PDF, spreadsheet, image, etc. | ❌                   | **Upload**, or drag & drop        |
+
+Pages can hold children just like folders, so a "Handbook" page can own the sections beneath it without needing a wrapper folder.
+
+## What Every Document Carries
+
+| Property           | Description                                                              |
+| ------------------ | ------------------------------------------------------------------------ |
+| **Name**           | Title of the folder, page, or file (an emoji icon can be added to pages)  |
+| **Categories**     | Entries from the organization's category catalog — a curated taxonomy     |
+| **Tags**           | Free-form platform tags, shared with the rest of Gauzy                    |
+| **Status**         | Processing lifecycle of an uploaded file: Processing, Ready, or Failed    |
+| **Knowledge**      | Whether the document is part of the organization's AI knowledge           |
+| **Review**         | Whether a human still needs to look at it                                 |
+| **Visibility**     | Organization or Private                                                   |
+| **Source**         | How it arrived: Upload, Editor, Import, System, and so on                 |
+| **Linked records** | Business records this document is attached to                             |
+
+## Linking Documents to Business Records
+
+A contract is more useful when it hangs off the invoice it backs. Any document can be linked to records elsewhere in the platform:
+
+| Record type  | Typical use                                     |
+| ------------ | ----------------------------------------------- |
+| **Invoice**  | Signed contract, purchase order, receipt        |
+| **Task**     | Specification, design file, acceptance criteria |
+| **Project**  | Statement of work, architecture notes           |
+| **Team**     | Team charter, working agreements                |
+| **Employee** | Offer letter, certification, review notes       |
+| **Contact**  | NDA, proposal, customer correspondence          |
+
+To link a record:
+
+1. Open the document and expand the detail panel
+2. Find **Linked records** and click **Link a record**
+3. Choose the record type, search for the record, and confirm
+
+Links are two-way references — removing a link never deletes the document or the record.
+
+## Where Things Happen
+
+| Screen                             | What you do there                                            | Needed permission |
+| ---------------------------------- | ------------------------------------------------------------ | ----------------- |
+| **Documents**                      | Browse the tree, search, filter, upload, open documents       | `DOCS_READ`       |
+| **Documents → Review queue**       | Approve or reject documents waiting on a human                | `DOCS_REVIEW`     |
+| **Settings → Documents**           | Organization defaults, category catalog, storage, AI status   | `DOCS_MANAGE`     |
+
+## Relationship to the Rest of the Platform
+
+Documents reuses the platform rather than duplicating it — the same tags, the same favorites, the same file storage, and the same permission system you already use elsewhere. It also supersedes two older areas:
+
+- **Organization Documents** — the flat list of document links
+- **Help Center** and the **Knowledge Base** — categorized articles
+
+Both keep working, and their content can be imported into the hub. See [Migrating from the Legacy Pages](./migrating-from-legacy).
+
+:::note
+The Documents hub is controlled by a feature flag. If you do not see it in the sidebar, an administrator has not enabled it for your organization yet.
+:::
+
+## Related Pages
+
+- [Uploading Files](./uploading-files) — drag & drop, supported types, processing
+- [Organizing Documents](./organizing) — folders, categories, tags, search, filters
+- [Writing Pages](./writing-pages) — the page editor, versions, export
+- [AI Knowledge](./ai-knowledge) — grounding assistant answers in your documents
+- [Sharing & Permissions](./sharing-and-permissions) — visibility and the `DOCS_*` permissions
+- [Tags & Labels](../tags-and-labels) — the platform-wide tag system
+- [Favorites](../favorites) — the platform-wide favorites system

--- a/website/docs/features/documents/reviews-and-approvals.md
+++ b/website/docs/features/documents/reviews-and-approvals.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 6
+---
+
+# Reviews & Approvals
+
+The review queue is where documents that need a human decision wait — and the reason AI-derived content never quietly becomes a source of truth.
+
+## Overview
+
+Most documents never need reviewing. Some do: a scan whose text could not be read, a file the classifier was unsure about, or content the AI itself wrote. Rather than let those slip into search results and AI answers unnoticed, the hub flags them and puts them in one place.
+
+Open it from **Documents → Review queue**. You need the `DOCS_REVIEW` permission to act there; anyone can see that a document is flagged, because it carries a **Needs review** badge and a banner:
+
+> **This document needs review** — It stays out of AI answers until someone approves it.
+
+## What Puts a Document Into Review
+
+| Reason                  | What happened                                                              |
+| ----------------------- | -------------------------------------------------------------------------- |
+| **Extraction failed**   | The file's text could not be read, so nothing can search or summarize it    |
+| **Low confidence**      | AI classification was unsure about what this document is                    |
+| **AI generated**        | The content was produced by AI rather than written by a person              |
+| **Requested manually**  | Somebody asked for a human to look at it                                    |
+
+The queue shows the reason as a badge on each row, along with the confidence score where there is one, so you can triage the obvious cases quickly.
+
+## Reviewing
+
+Each row gives you the document's name, why it is flagged, its source, its categories, and when it changed. From there:
+
+1. Click the info button to open the **details**, or the eye to **preview** the file
+2. Decide
+3. Click **Approve** or **Reject**
+
+**Reject** offers an optional reason. Recording why something was rejected is worth the extra few seconds — the next person to open the document will see it.
+
+You can also select multiple rows and use **Approve** or **Reject** from the bulk bar.
+
+## Requesting a Review
+
+Anyone who can edit a document can send it for review: open the detail panel and click **Request review**. An optional reason can be attached.
+
+> The document moves to the review queue and stays out of AI answers until someone approves it.
+
+This is the only way into the queue when AI features are switched off, and it is genuinely useful on its own — flagging a policy that looks out of date, or a contract nobody has confirmed is the signed copy.
+
+## The Rule That Matters
+
+**AI-derived content that has not been approved stays out of AI answers.**
+
+Concretely:
+
+| State                                                        | Used in AI answers |
+| ------------------------------------------------------------ | ------------------ |
+| Waiting for review because it was **AI generated**            | ❌                 |
+| Waiting for review because of **low confidence**              | ❌                 |
+| **Rejected** for any reason                                   | ❌                 |
+| **Approved**                                                  | ✅                 |
+| Waiting for review because extraction failed or somebody asked | ✅ *               |
+
+\* These two reasons flag a document for human attention without cutting it off — a manually flagged document that is already in AI knowledge keeps working while it waits, and a document whose text could not be read has nothing to contribute either way.
+
+The point of the rule is to stop a machine's guess becoming a machine's evidence. If AI wrote something, or AI was unsure what something was, a person decides before it can shape the next answer.
+
+:::note
+Approving a document does not import it into AI knowledge. The two are separate decisions — see [AI Knowledge](./ai-knowledge).
+:::
+
+## Related Pages
+
+- [AI Knowledge](./ai-knowledge) — importing, excluding, and what is excluded
+- [Uploading Files](./uploading-files) — fixing failed extraction
+- [Sharing & Permissions](./sharing-and-permissions) — who holds `DOCS_REVIEW`
+- [Approval Workflows](../approval-workflows) — approvals elsewhere in Gauzy

--- a/website/docs/features/documents/settings.md
+++ b/website/docs/features/documents/settings.md
@@ -36,7 +36,7 @@ Three settings that apply to newly created documents in this organization.
 | Setting                                  | Effect                                                                  |
 | ---------------------------------------- | ----------------------------------------------------------------------- |
 | **Add uploads to AI knowledge by default** | Pre-selects the AI knowledge option on the upload dialog               |
-| **Classify with AI**                     | Suggests categories, tags, and a summary automatically for new uploads  |
+| **Classify with AI**                     | Default for the upload dialog's own **Classify with AI** toggle, which suggests categories, tags, and a summary. Uploaders can override it per batch |
 | **Visibility**                           | Whether new documents start as Organization or Private                  |
 
 :::tip

--- a/website/docs/features/documents/settings.md
+++ b/website/docs/features/documents/settings.md
@@ -1,0 +1,153 @@
+---
+sidebar_position: 8
+---
+
+# Documents Settings
+
+Organization defaults, the category catalog, storage, and the deployment settings an administrator controls.
+
+## Overview
+
+Open **Settings → Documents**. The screen needs the `DOCS_MANAGE` permission and is organized as four cards:
+
+1. **AI knowledge status** — what this deployment can actually do
+2. **Organization defaults** — what new documents inherit
+3. **Storage** — how much of the quota is in use
+4. **Categories** — the category catalog
+
+## AI Knowledge Status
+
+A read-only report of the deployment's capabilities, so you know why AI features behave the way they do before changing anything else.
+
+| Line                            | Meaning                                                                     |
+| ------------------------------- | --------------------------------------------------------------------------- |
+| **Vector search is available**  | Meaning-based search is working                                             |
+| **Vector search is unavailable** | Answers fall back to keyword search                                        |
+| **An embedding provider is configured** | Documents can be prepared for AI answers                            |
+| **No embedding provider is configured** | Documents cannot be indexed — AI answers will not work              |
+| **Embedding model**             | The model currently in use                                                  |
+
+If either line shows a warning, see [Environment Settings](#environment-settings-for-administrators) below.
+
+## Organization Defaults
+
+Three settings that apply to newly created documents in this organization.
+
+| Setting                                  | Effect                                                                  |
+| ---------------------------------------- | ----------------------------------------------------------------------- |
+| **Add uploads to AI knowledge by default** | Pre-selects the AI knowledge option on the upload dialog               |
+| **Classify with AI**                     | Suggests categories, tags, and a summary automatically for new uploads  |
+| **Visibility**                           | Whether new documents start as Organization or Private                  |
+
+:::tip
+Setting **Visibility** to **Private** by default suits organizations handling sensitive material — documents then start closed and are opened deliberately, rather than the other way round.
+:::
+
+## Storage
+
+Shows how much storage the organization's documents occupy, with a progress bar and a warning as you approach the limit.
+
+Two things people are often surprised by:
+
+- **Archived files still count.** As the hint says, the usage figure "counts every uploaded file, including archived ones — their bytes still exist."
+- **When the limit is reached, new uploads are rejected.** They are not silently truncated.
+
+If the organization has no quota, the card simply reports total usage instead.
+
+## The Category Catalog
+
+Categories are the curated taxonomy used to classify documents (and what AI classification chooses from). Each organization starts with eleven:
+
+**Invoice · Contract · Report · Policy · Customer List · Expense · HR · Legal · Meeting Notes · Specification · Other**
+
+The table lists each category with its color, description, and how many documents use it. You can:
+
+| Action     | Notes                                                                          |
+| ---------- | ------------------------------------------------------------------------------ |
+| **New category** | Add one of your own with a name, color, and description                  |
+| **Edit**   | Rename, recolor, or describe any category, including the built-in ones          |
+| **Merge into…** | Move every document into another category and remove this one              |
+| **Delete** | Only available for categories you created                                       |
+
+Built-in categories are marked **System**. They can be renamed and merged but not deleted, so classification never breaks because a category vanished underneath it.
+
+:::note
+Keep the catalog small and meaningful. AI classification picks from this list, and a catalog of eighty near-identical categories produces worse suggestions than one of a dozen clear ones.
+:::
+
+## Environment Settings for Administrators
+
+The Documents hub works with no configuration at all: files upload, their text is read out, and they become searchable. Everything below is optional tuning applied when the platform starts, and all of it ships commented out.
+
+:::warning
+**AI features are off by default.** Turn `GAUZY_DOCS_AI_ENABLED` on only after an AI provider is configured. Documents reuses the platform's AI chat providers, including per-tenant keys.
+:::
+
+### AI and Knowledge
+
+| Variable                                   | Default                  | Controls                                                                    |
+| ------------------------------------------ | ------------------------ | --------------------------------------------------------------------------- |
+| `GAUZY_DOCS_AI_ENABLED`                    | `false`                  | Master switch for classification, summaries, and embeddings                 |
+| `GAUZY_DOCS_CLASSIFY_MODEL`                | AI chat default model    | Model used to classify documents                                            |
+| `GAUZY_DOCS_EMBEDDING_MODEL`               | `text-embedding-3-small` | Model used to prepare documents for AI answers                              |
+| `GAUZY_DOCS_EMBEDDING_DIMS`                | `1536`                   | Vector dimensions — must match the storage column                           |
+| `GAUZY_DOCS_EMBED_BATCH_SIZE`              | `64`                     | How many passages are embedded per request                                  |
+| `GAUZY_DOCS_CLASSIFY_SAMPLE_CHARS`         | `4000`                   | How much of a document is sampled for classification                        |
+| `GAUZY_DOCS_VECTOR_STORE`                  | best available           | Pins the search backend; degrades to keyword search when unavailable        |
+| `GAUZY_DOCS_RETRIEVAL_TOPK_MAX`            | `12`                     | Maximum passages returned for one question                                  |
+| `GAUZY_DOCS_CHUNK_TOKENS`                  | `512`                    | Size of each passage                                                        |
+| `GAUZY_DOCS_CHUNK_OVERLAP_TOKENS`          | `64`                     | Overlap between neighbouring passages                                       |
+| `GAUZY_DOCS_AUTO_REINDEX_ON_MODEL_CHANGE`  | `false`                  | Re-prepare every document when the embedding model changes                  |
+| `GAUZY_DOCS_RETRIEVAL_LOG_ENABLED`         | `true`                   | Logs query length, result counts, and latency — never the query text        |
+
+Meaning-based search needs PostgreSQL with vector support. On other databases, or when that support is missing, retrieval falls back to keyword search automatically and the settings screen reports it.
+
+:::warning
+Leave `GAUZY_DOCS_AUTO_REINDEX_ON_MODEL_CHANGE` off unless you mean it. Changing the embedding model re-prepares every document in the deployment, which costs real money at your AI provider.
+:::
+
+### Uploads and Processing
+
+| Variable                              | Default                | Controls                                                         |
+| ------------------------------------- | ---------------------- | ---------------------------------------------------------------- |
+| `GAUZY_DOCS_MAX_FILE_SIZE`            | `52428800` (50 MB)     | Maximum size of a single uploaded file                           |
+| `GAUZY_DOCS_MAX_EXTRACTED_CHARS`      | `5000000`              | Cap on how much text is stored per document                      |
+| `GAUZY_DOCS_MAX_BINARY_BYTES`         | `10485760` (10 MB)     | Cap on a page's stored editing data                              |
+| `GAUZY_DOCS_QUEUE_CONCURRENCY`        | `2`                    | How many documents are processed at once per server              |
+| `GAUZY_DOCS_STUCK_THRESHOLD_MINUTES`  | `30`                   | How long before a stalled document is picked up again            |
+
+### Storage and Versions
+
+| Variable                               | Default | Controls                                                              |
+| -------------------------------------- | ------- | --------------------------------------------------------------------- |
+| `GAUZY_DOCS_ORG_QUOTA_BYTES`           | `0`     | Default storage quota per organization; `0` means unlimited            |
+| `GAUZY_DOCS_VERSION_DEBOUNCE_MINUTES`  | `10`    | Minimum minutes between automatic version snapshots while editing      |
+
+A per-organization quota overrides the deployment default.
+
+### Inbound Email Capture (Advanced)
+
+Documents emailed to a per-organization address can land in the hub for review. This is off unless it is explicitly enabled **and** a webhook secret is set. Captured documents always go through review first and are never added to AI knowledge automatically.
+
+| Variable                                  | Default              | Controls                                     |
+| ----------------------------------------- | -------------------- | -------------------------------------------- |
+| `GAUZY_DOCS_INBOUND_EMAIL_ENABLED`        | `false`              | Master switch for inbound capture            |
+| `GAUZY_DOCS_INBOUND_DOMAIN`               | unset                | Domain used for capture addresses            |
+| `GAUZY_DOCS_INBOUND_WEBHOOK_SECRET`       | unset                | Shared secret used to sign inbound messages  |
+| `GAUZY_DOCS_INBOUND_MAX_MESSAGE_BYTES`    | `26214400` (25 MB)   | Maximum size of one inbound message          |
+
+:::note
+The defaults above are the values that apply when a variable is left unset. The sample environment file shows illustrative values on some of these lines; because those lines are commented out, they are examples rather than the effective defaults.
+:::
+
+## Turning Documents On or Off
+
+The hub is governed by the **Documents** feature. Administrators enable or disable it per organization in **Settings → Features**. When it is off, the sidebar entry disappears and the older Organization Documents and Help Center pages behave exactly as they always have — see [Migrating from the Legacy Pages](./migrating-from-legacy).
+
+## Related Pages
+
+- [Documents Overview](./overview) — what the hub is
+- [AI Knowledge](./ai-knowledge) — what the AI settings actually change
+- [Sharing & Permissions](./sharing-and-permissions) — who can reach this screen
+- [Migrating from the Legacy Pages](./migrating-from-legacy) — the feature flag and import
+- [Configuration](../../getting-started/configuration) — platform-wide environment settings

--- a/website/docs/features/documents/sharing-and-permissions.md
+++ b/website/docs/features/documents/sharing-and-permissions.md
@@ -1,0 +1,109 @@
+---
+sidebar_position: 7
+---
+
+# Sharing & Permissions
+
+Who can see a document, who can change it, and how to share something private with specific people.
+
+## Overview
+
+Access to a document is decided by two things working together:
+
+1. **Your role's permissions** — what you may do with documents in general
+2. **The document's visibility** — who that particular document is for
+
+Sharing sits on top as an additive overlay: it can grant access to a private document, and it never takes access away.
+
+## Visibility
+
+Every document is either visible to the organization or private.
+
+| Visibility       | Who can open it                                                        |
+| ---------------- | ---------------------------------------------------------------------- |
+| **Organization** | Everyone in the organization who can read documents                     |
+| **Private**      | The creator, administrators, and the people or teams it is shared with  |
+
+Change it from the document's detail panel. The hint in the UI says it plainly: "Private documents are visible to you, admins and people you share them with".
+
+Visibility is **not inherited** — putting a private document inside a public folder does not make it public, and vice versa. Navigating *to* a document does still depend on being able to see the folders above it.
+
+An organization-wide default for new documents can be set in **Settings → Documents**.
+
+## Sharing a Private Document
+
+Sharing only applies to **private** documents. If a document is visible to the whole organization there is nothing to grant, and the share dialog says so:
+
+> This document is visible to the whole organization, so sharing adds nothing. Switch it to Private to share it with specific people or teams.
+
+To share:
+
+1. Open the document and click **Share**
+2. Choose **Person** or **Team**
+3. Pick exactly one person or one team
+4. Choose the access level
+5. Click **Add**
+
+| Access level    | Grants                                                       |
+| --------------- | ------------------------------------------------------------ |
+| **Can view**    | Opening, previewing, and downloading the document            |
+| **Can comment** | Viewing, plus commenting once document comments arrive        |
+| **Can edit**    | Viewing plus changing the document                            |
+
+Two limits are worth knowing:
+
+- **"Can edit" is not a permission grant.** As the dialog notes, it "only takes effect for people who also have permission to edit documents". Sharing cannot give somebody an ability their role does not have.
+- **Only the document's creator or an administrator can share it.**
+
+Use **Remove access** to revoke a share at any time.
+
+:::note
+Comment threads on documents are not available yet — the **Can comment** level is in place ready for them. For now, treat it as equivalent to **Can view**.
+:::
+
+## The `DOCS_*` Permissions
+
+Seven permissions control the Documents hub. They can be adjusted per role in **Settings → Roles & Permissions**.
+
+| Permission        | Allows                                                                                    |
+| ----------------- | ----------------------------------------------------------------------------------------- |
+| `DOCS_READ`       | Browse the tree, search, open documents, download files                                   |
+| `DOCS_CREATE`     | Create folders and pages, upload files, duplicate documents                                |
+| `DOCS_UPDATE`     | Edit documents, move, rename, archive, share, link records, correct extracted text         |
+| `DOCS_DELETE`     | Delete archived documents                                                                  |
+| `DOCS_MANAGE`     | Open Documents settings, manage the category catalog, run the legacy import                |
+| `DOCS_REVIEW`     | Approve and reject documents in the review queue                                            |
+| `DOCS_AI_IMPORT`  | Import documents into AI knowledge, exclude them, and re-index                              |
+
+## Default Role Matrix
+
+This is what each role gets out of the box.
+
+| Role            | READ | CREATE | UPDATE | DELETE | MANAGE | REVIEW | AI IMPORT |
+| --------------- | :--: | :----: | :----: | :----: | :----: | :----: | :-------: |
+| **Super Admin** |  ✅  |   ✅   |   ✅   |   ✅   |   ✅   |   ✅   |       ✅       |
+| **Admin**       |  ✅  |   ✅   |   ✅   |   ✅   |   ✅   |   ✅   |       ✅       |
+| **Manager**     |  ✅  |   ✅   |   ✅   |   ✅   |   ❌   |   ✅   |       ✅       |
+| **Employee**    |  ✅  |   ✅   |   ✅   |   ❌   |   ❌   |   ❌   |       ❌       |
+| **Data Entry**  |  ✅  |   ✅   |   ✅   |   ❌   |   ❌   |   ❌   |       ❌       |
+| **Viewer**      |  ✅  |   ❌   |   ❌   |   ❌   |   ❌   |   ❌   |       ❌       |
+| **Candidate**   |  ❌  |   ❌   |   ❌   |   ❌   |   ❌   |   ❌   |       ❌       |
+| **Interviewer** |  ❌  |   ❌   |   ❌   |   ❌   |   ❌   |   ❌   |       ❌       |
+
+A few consequences of these defaults:
+
+- **Employees can write.** The hub is not read-only for staff — they can create pages, upload files, and edit what they own.
+- **Managers can review and delete but cannot administer.** A manager cannot change the category catalog or the organization defaults; that stays with administrators.
+- **Candidates and interviewers see nothing.** Documents does not appear in their sidebar at all.
+
+:::tip
+These are defaults, not fixed rules. Roles are editable in **Settings → Roles & Permissions**, and custom roles can be given any combination of the seven.
+:::
+
+## Related Pages
+
+- [Documents Overview](./overview) — where each screen lives
+- [Reviews & Approvals](./reviews-and-approvals) — what `DOCS_REVIEW` unlocks
+- [AI Knowledge](./ai-knowledge) — what `DOCS_AI_IMPORT` unlocks
+- [Settings](./settings) — what `DOCS_MANAGE` unlocks
+- [Custom Roles & Permissions](../custom-roles-permissions) — editing roles

--- a/website/docs/features/documents/uploading-files.md
+++ b/website/docs/features/documents/uploading-files.md
@@ -26,12 +26,13 @@ Before the upload starts you can set everything the files should inherit:
 | **Categories**        | Categories applied to every file in this batch                                  |
 | **Tags**              | Tags applied to every file in this batch                                        |
 | **Add to AI knowledge** | Make these documents available to AI-powered answers                          |
+| **Classify with AI**  | Let AI suggest categories, tags and a summary for this batch                     |
 | **Visibility**        | Organization or Private                                                         |
 
 Each file gets its own progress row. If one fails, the rest continue — use **Retry** on the failed row, or **Clear finished** to tidy up the list.
 
 :::note
-Whether uploads are automatically classified by AI is an organization-wide setting, not a per-upload choice. An administrator controls it in **Settings → Documents**.
+**Classify with AI** starts from your organization's default and applies to this batch only — turning it off here does not change the setting for anyone else. An administrator sets the default in **Settings → Documents**. The toggle is hidden when no AI provider is configured, since there would be nothing to classify with.
 :::
 
 ## Supported File Types

--- a/website/docs/features/documents/uploading-files.md
+++ b/website/docs/features/documents/uploading-files.md
@@ -1,0 +1,110 @@
+---
+sidebar_position: 2
+---
+
+# Uploading Files
+
+Get PDFs, spreadsheets, contracts, and scans into the Documents hub, and understand what happens to them afterwards.
+
+## Overview
+
+There are three ways to upload:
+
+- **Drag & drop** — drop files anywhere on the Documents page. A hint appears as soon as you start dragging.
+- **Upload button** — click **Upload** in the page header.
+- **Upload here** — right-click any folder in the tree and choose **Upload here** to preselect the destination.
+
+You can upload **up to 10 files at once**, and each file may be up to **50 MB** by default. Administrators can lower or raise the size limit for a deployment — see [Settings](./settings).
+
+## The Upload Dialog
+
+Before the upload starts you can set everything the files should inherit:
+
+| Field                 | Description                                                                    |
+| --------------------- | ------------------------------------------------------------------------------ |
+| **Destination folder** | Where the files land in the tree — defaults to the folder you were browsing     |
+| **Categories**        | Categories applied to every file in this batch                                  |
+| **Tags**              | Tags applied to every file in this batch                                        |
+| **Add to AI knowledge** | Make these documents available to AI-powered answers                          |
+| **Visibility**        | Organization or Private                                                         |
+
+Each file gets its own progress row. If one fails, the rest continue — use **Retry** on the failed row, or **Clear finished** to tidy up the list.
+
+:::note
+Whether uploads are automatically classified by AI is an organization-wide setting, not a per-upload choice. An administrator controls it in **Settings → Documents**.
+:::
+
+## Supported File Types
+
+Uploads are checked by inspecting the file's actual content, not just its extension. A file whose content does not match its extension is rejected with "This file's content doesn't match its extension".
+
+| Format                | Extensions            |
+| --------------------- | --------------------- |
+| PDF                   | `.pdf`                |
+| Word                  | `.docx`               |
+| Excel                 | `.xlsx`               |
+| PowerPoint            | `.pptx`               |
+| OpenDocument Text     | `.odt`                |
+| OpenDocument Spreadsheet | `.ods`             |
+| CSV                   | `.csv`                |
+| Plain text            | `.txt`                |
+| Markdown              | `.md`                 |
+| HTML                  | `.html`, `.htm`       |
+| Images                | `.png`, `.jpg`, `.jpeg`, `.webp`, `.gif` |
+
+:::warning
+SVG files and other XML-based markup are never accepted, in any form. They can carry active content that would run in a colleague's browser, so the hub rejects them outright rather than trying to clean them.
+:::
+
+## What Happens During Processing
+
+Every uploaded file moves through a short lifecycle. The current stage is shown as a badge in the table and in the detail panel.
+
+| Status         | Meaning                                                                  |
+| -------------- | ------------------------------------------------------------------------ |
+| **Processing** | The file is stored and its text is being read out                        |
+| **Ready**      | Processing finished — the file is searchable and can be previewed        |
+| **Failed**     | The text could not be read; the file itself is safe and still downloadable |
+
+Reading the text out is what makes content search and AI answers possible. It works for:
+
+**PDF · Word (`.docx`) · Excel (`.xlsx`) · CSV · plain text · Markdown · HTML**
+
+Other accepted formats — PowerPoint, OpenDocument files, and images — upload and store correctly, but their text cannot be read yet. They finish as **Failed** and go to the review queue so somebody notices. The file itself is intact: it can be downloaded, previewed, linked, categorized, and tagged like any other.
+
+:::tip
+A **Failed** status only ever means "the text could not be read". It never means the file was lost or damaged.
+:::
+
+## When Extraction Fails
+
+Open the document and use the detail panel:
+
+1. **Retry** — re-runs processing. Useful after a transient problem.
+2. **Edit extracted text** — type or paste the text yourself (see below).
+3. Do nothing — the file stays usable as a plain attachment.
+
+A failed file is flagged **Needs review** with the reason **Extraction failed**, so it turns up in the [review queue](./reviews-and-approvals) instead of quietly disappearing.
+
+## Correcting Extracted Text
+
+Scans, unusual layouts, and multi-column PDFs can produce messy text. Because search and AI answers read that text, it is worth fixing.
+
+1. Open the document's detail panel
+2. Click **Edit extracted text**
+3. Correct the text — the dialog reminds you that "search and AI answers use this text"
+4. Click **Save & re-index**
+
+Once you have edited the text by hand it is protected: re-running processing will not silently overwrite your corrections.
+
+## Storage
+
+Uploads count against the organization's storage quota if one is set. Archived files still count — their bytes still exist. Administrators can see current usage in **Settings → Documents**.
+
+## Related Pages
+
+- [Documents Overview](./overview) — what the hub is
+- [Organizing Documents](./organizing) — folders, categories, search
+- [Reviews & Approvals](./reviews-and-approvals) — the review queue
+- [AI Knowledge](./ai-knowledge) — adding documents to AI answers
+- [Settings](./settings) — size limits and storage quota

--- a/website/docs/features/documents/writing-pages.md
+++ b/website/docs/features/documents/writing-pages.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 4
+---
+
+# Writing Pages
+
+Author wiki-style pages directly in the platform, with autosave, version history, and export.
+
+## Overview
+
+A **page** is a document you write rather than upload. Pages support headings, lists, tables, task lists, callouts, images, attachments, mentions, and math — and, like folders, they can contain child documents, so a handbook page can own its own sections.
+
+To create one:
+
+1. Click **New page** in the page header, or **New page** in a folder's tree menu
+2. Give it a name (you can also pick an emoji icon for it)
+3. Start typing
+
+## The Editor
+
+The editor is block-based. Start a new line and the placeholder tells you what to do: **Type '/' for commands…**
+
+### The Slash Menu
+
+Type `/` anywhere to insert a block. Commands are grouped:
+
+| Group        | Commands                                                                  |
+| ------------ | ------------------------------------------------------------------------- |
+| **Basic**    | Text, Heading 1, Heading 2, Heading 3, Quote, Divider, Code block          |
+| **Lists**    | Bullet list, Numbered list, Task list                                      |
+| **Media**    | Image, Attachment, Video, Embed, Table                                     |
+| **Advanced** | Callout, Warning callout, Toggle, Emoji, Math formula, Mention, Link document |
+
+Keep typing after the `/` to filter the list.
+
+### Formatting
+
+Select any text and a formatting bar appears: **Bold, Italic, Underline, Strikethrough, Inline code, Add link, Highlight, Text color**, and **Turn into** for converting a block into a different one. Text alignment, subscript, and superscript are available too, and code blocks are syntax-highlighted.
+
+### Tables
+
+Insert a table from the slash menu — it starts as a 3 × 3 grid with a header row. Click into it and a table toolbar offers: add or delete rows and columns, toggle the header row or header column, merge cells, split a cell, and delete the table. Columns can be resized by dragging.
+
+### Task Lists
+
+**Task list** blocks give you checkboxes you can tick inline — useful for onboarding checklists and runbooks that people work through as they read.
+
+### Callouts
+
+Two callout styles are available — a neutral **Callout** for asides and a **Warning callout** for things that must not be missed.
+
+### Images and Attachments
+
+Insert an **Image** or **Attachment** from the slash menu, or simply **drag a file into the page** or paste it from the clipboard. Uploads show their progress inline and can be retried if they fail. An attachment block can be downloaded directly or opened in Documents.
+
+### Mentions and Document Links
+
+| Trigger | Inserts                                                        |
+| ------- | -------------------------------------------------------------- |
+| `@`     | A mention of a colleague                                       |
+| `+`     | A link to another document in the hub                          |
+| `:`     | An emoji                                                       |
+
+Document links keep pages connected — a policy page can point at the contract it derives from without anyone hunting through the tree.
+
+### Math
+
+The **Math formula** block renders mathematical notation, for formulas in finance, engineering, or compensation documentation.
+
+### Table of Contents
+
+The **Contents** panel builds a live table of contents from your headings and scrolls the page when you click an entry. If a page has no headings yet, the panel tells you so.
+
+### Info Panel
+
+The **Info** panel reports word count, character count, estimated read time, and when the page was last updated. A **Full width** toggle widens the writing area, and there is a switch to show invisible characters when whitespace matters.
+
+## Autosave
+
+You never press Save. The editor saves as you type and shows its state next to the title:
+
+| Indicator             | Meaning                                                        |
+| --------------------- | -------------------------------------------------------------- |
+| **Saving…**           | A save is in flight                                            |
+| **Saved**             | Everything is stored                                           |
+| **Offline — retrying** | The connection dropped; your work is queued and will be sent   |
+| **Save failed**       | The save could not be completed — use **Retry**                |
+
+If you try to navigate away with unsaved changes, the editor warns you first.
+
+### If Someone Else Edited the Same Page
+
+Should the page change elsewhere while you were writing, the editor tells you rather than silently overwriting anything, and offers two ways out:
+
+- **Reload latest** — take the other version and discard your local changes
+- **Keep mine as copy** — save your work as a separate copy so nothing is lost
+
+## Locking a Page
+
+Use **Lock** to freeze a finished page. A locked page shows the banner "This page is locked — viewing only" and cannot be edited until someone unlocks it. This is the right tool for a signed policy or an approved process description.
+
+## Version History
+
+Pages are snapshotted automatically as they are edited — by default no more often than every 10 minutes, so history stays readable. You can also force a snapshot at a meaningful moment with **Save version now**.
+
+Open **Version history** to see the list. From there you can:
+
+1. Select a version to preview it
+2. Check that it is the one you want
+3. Click **Restore** and confirm
+
+Restoring is non-destructive: the current content is snapshotted first, so a restore can itself be undone. The confirmation says as much — "A new version will be created on top."
+
+## Duplicating and Moving
+
+- **Duplicate** copies a page. **Duplicate with children** copies its whole subtree.
+- **Move…** re-parents a page anywhere in the tree.
+
+A duplicated page starts fresh: it is not part of AI knowledge and carries no review state, versions, or shares from the original.
+
+## Export
+
+| Action              | Result                                                            |
+| ------------------- | ----------------------------------------------------------------- |
+| **Copy as Markdown** | Puts the page on your clipboard as Markdown                       |
+| **Export Markdown** | Downloads the page as a `.md` file                                |
+| **Print / PDF**     | Opens the print dialog — choose "Save as PDF" there to get a PDF   |
+
+## Related Pages
+
+- [Documents Overview](./overview) — the three kinds of item
+- [Organizing Documents](./organizing) — moving, archiving, and finding pages
+- [Sharing & Permissions](./sharing-and-permissions) — who can edit a page
+- [AI Knowledge](./ai-knowledge) — making a page answerable by the assistant
+- [Comments & Mentions](../comments-and-mentions) — mentions elsewhere in Gauzy

--- a/website/docs/features/help-center.md
+++ b/website/docs/features/help-center.md
@@ -6,6 +6,12 @@ sidebar_position: 59
 
 Build a customer-facing help center.
 
+:::important
+**Superseded by the Documents hub.** The Help Center has been consolidated into [Documents](./documents/overview), where categories become folders and articles become pages in one searchable tree — alongside uploaded files, review, and optional AI knowledge.
+
+This page continues to work exactly as described below until an administrator enables the Documents feature for your organization. When they do, this area redirects to the hub, and its categories and articles can be imported — see [Migrating from the Legacy Pages](./documents/migrating-from-legacy). Nothing is deleted at any point.
+:::
+
 ## Overview
 
 The Help Center provides:
@@ -68,5 +74,7 @@ Help center content is accessible via the Knowledge Base API.
 
 ## Related Pages
 
+- [Documents Overview](./documents/overview) — the hub that supersedes this page
+- [Migrating from the Legacy Pages](./documents/migrating-from-legacy) — importing articles into the hub
 - [Knowledge Base](./knowledge-base) — internal knowledge
 - [Comments & Mentions](./comments-and-mentions) — collaboration

--- a/website/docs/features/knowledge-base.md
+++ b/website/docs/features/knowledge-base.md
@@ -6,6 +6,12 @@ sidebar_position: 51
 
 Build an internal knowledge base and help center.
 
+:::important
+**Superseded by the Documents hub.** The Knowledge Base has been consolidated into [Documents](./documents/overview), which covers the same ground — categorized articles and rich text — and adds folders, file uploads, content search, review, and optional AI-powered answers grounded in your own documents.
+
+This page continues to work exactly as described below until an administrator enables the Documents feature for your organization. When they do, this area redirects to the hub, and its categories and articles can be imported — see [Migrating from the Legacy Pages](./documents/migrating-from-legacy). Nothing is deleted at any point.
+:::
+
 ## Overview
 
 The Knowledge Base plugin provides:
@@ -63,5 +69,7 @@ Users can search across all published articles using the search bar.
 
 ## Related Pages
 
+- [Documents Overview](./documents/overview) — the hub that supersedes this page
+- [Migrating from the Legacy Pages](./documents/migrating-from-legacy) — importing articles into the hub
 - [Comments & Mentions](./comments-and-mentions) — collaboration
 - [Help Center](./help-center) — customer-facing help

--- a/website/docs/features/organization-documents.md
+++ b/website/docs/features/organization-documents.md
@@ -6,6 +6,12 @@ sidebar_position: 50
 
 Manage shared documents, wikis, and knowledge bases within your organization.
 
+:::important
+**Superseded by the Documents hub.** Organization Documents has been replaced by [Documents](./documents/overview) — a full document hub with folders, wiki pages, file uploads with text extraction, search, review, and optional AI knowledge.
+
+This page continues to work exactly as described below until an administrator enables the Documents feature for your organization. When they do, this area redirects to the hub, and its content can be imported — see [Migrating from the Legacy Pages](./documents/migrating-from-legacy). Nothing is deleted at any point.
+:::
+
 ## Overview
 
 Organization Documents provide a centralized location for managing shared documentation — policies, procedures, knowledge articles, and reference materials.
@@ -27,5 +33,7 @@ Organization Documents provide a centralized location for managing shared docume
 
 ## Related Pages
 
+- [Documents Overview](./documents/overview) — the hub that supersedes this page
+- [Migrating from the Legacy Pages](./documents/migrating-from-legacy) — importing this list into the hub
 - [Email Templates](./email-templates) — email template management
 - [Project Management](./project-management) — project documentation

--- a/website/docs/getting-started/introduction.md
+++ b/website/docs/getting-started/introduction.md
@@ -19,6 +19,7 @@ slug: /
 - **Applicant Tracking System** (ATS) — candidates, interviews, hiring workflows
 - **Work & Project Management** (PM) — projects, tasks, sprints, goals, KPIs
 - **Time Tracking & Productivity** — time logs, timesheets, activity monitoring, screenshots
+- **Documents & Knowledge** — a central document hub with wiki pages, file uploads, search, and optional AI-powered answers
 
 ## Why "Gauzy"?
 
@@ -119,6 +120,7 @@ Ever® Gauzy™ is part of the larger [Ever® Platform](https://ever.co) ecosyst
 
 ## Quick Links
 
+- **[Documents](../features/documents/overview)** — the central document hub
 - **[Quick Start](./quick-start)** — get running in minutes
 - **[Installation](./installation)** — detailed setup guide
 - **[Configuration](./configuration)** — configure environment variables, database, and services

--- a/website/docs/plugins-built-in/overview.md
+++ b/website/docs/plugins-built-in/overview.md
@@ -81,6 +81,7 @@ UI plugins provide:
 
 | Plugin              | Package                         | Description                  |
 | ------------------- | ------------------------------- | ---------------------------- |
+| [Documents](../features/documents/overview) | `@gauzy/plugin-docs` | Document hub, wiki pages, review, AI knowledge |
 | **Knowledge Base**  | `@gauzy/plugin-knowledge-base`  | Help center / knowledge base |
 | **Product Reviews** | `@gauzy/plugin-product-reviews` | Product review system        |
 | **Job Search**      | `@gauzy/plugin-job-search`      | Job board search integration |
@@ -134,6 +135,7 @@ The [Jobs UI plugins](./jobs-ui/overview) use a parent-child architecture. `Jobs
 
 | Plugin | Package | Description |
 | ------ | ------- | ----------- |
+| [Documents UI](../features/documents/overview) | `@gauzy/plugin-docs-ui` | Documents hub, tree, page editor, review queue |
 | **Knowledge Base UI** | `@gauzy/plugin-knowledge-base-ui` | Knowledge base frontend |
 | **Onboarding UI** | `@gauzy/plugin-onboarding-ui` | Setup/onboarding wizard UI |
 | **Legal UI** | `@gauzy/plugin-legal-ui` | Privacy/Terms pages |


### PR DESCRIPTION
Publishes the Documents feature documentation to docs.gauzy.co: 10 new pages under `website/docs/features/documents/`, superseded-by notices on the legacy Organization Documents / Help Center / Knowledge Base pages, and the per-upload AI classification override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)