### PR TITLE
docs: attach files + library picker in AI chat

### DIFF
--- a/website/docs/features/ai-agent-chat.md
+++ b/website/docs/features/ai-agent-chat.md
@@ -59,6 +59,19 @@ On the currently open page, the agent can:
 Any action that modifies data — submitting a form, creating, updating, or deleting a record — always pauses and asks for your approval in the chat before it executes. Nothing is written on your behalf without an explicit click on **Approve**.
 :::
 
+### Attach files and discuss them
+
+Two ways to bring a document into the conversation:
+
+- **Attach a file** (paperclip icon) — the file is uploaded into the [Documents](./documents/overview) hub (source: *Chat*), so it exists as a regular document from that moment, and it is attached to your next message.
+- **Choose from the library** (folder icon) — search and pick any document you already have in Documents.
+
+Attached documents appear as chips on your message; the assistant reads them with its document tools, in your own permission scope, and can quote and cite them. A freshly uploaded file may need a moment of processing before its text is readable — the assistant will say so and you can simply ask again.
+
+:::note
+Attaching requires the Documents feature and, for uploads, the permission to create documents. Without Documents, a basic attach still works but the assistant can only see the file's name.
+:::
+
 ### Voice dictation
 
 The microphone icon in the chat input records speech and transcribes it into the message box — a recording panel above the input shows the elapsed time and offers **Cancel**, **Done**, and an optional auto-send toggle. Dictation requires a configured provider with speech support (currently OpenAI).

--- a/website/docs/plugins-built-in/ai-chat-plugin.md
+++ b/website/docs/plugins-built-in/ai-chat-plugin.md
@@ -23,6 +23,7 @@ Backend and frontend plugins powering the embedded [AI Agent Chat](../features/a
 | `POST /api/ai-chat`                        | One chat turn as a streaming UI message response             |
 | `GET /api/ai-chat/config`                  | Feature/provider availability for the current tenant (no secrets) |
 | `POST /api/ai-chat/transcribe`             | Speech-to-text for the chat's voice dictation (25 MB limit)  |
+| `POST /api/ai-chat/attachments`            | Fallback chat-local file storage when the Documents feature is unavailable (uploads normally go straight to the Documents upload endpoint with source `CHAT`) |
 | `GET /api/ai-chat/providers/:id/models`    | A provider's model catalogue, for the settings model picker  |
 | `GET`/`POST`/`PUT`/`DELETE` `/api/ai-chat/credentials` | Per-tenant BYOK credential management (keys masked on read) |
 | `POST /api/ai-chat/credentials/connect`    | Completes a provider "Connect" flow (OpenRouter PKCE) server-side |


### PR DESCRIPTION
Documents the now-live chat attachments: attach-a-file (uploads into the Documents hub with source `CHAT`, attached to the next message), choose-from-library, chips on the message, the still-processing note, availability requirements (Documents feature + create permission), and the fallback endpoint in the plugin page's endpoint table.

Ships together with ever-gauzy#9959 (id-first uploads), but accurate for what is on stage today either way.

Codacy MD013 fails on table rows by construction — same as #130/#134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)